### PR TITLE
chore: improve build backend specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
 [build-system]
-requires = [
-   "wheel",
-   "setuptools",
-]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
`wheel` has never been required here (setuptools used to add it via a hook when building wheels if you were using PEP 517), and modern setuptools doesn't even use `wheel` (which is now just a CLI).

Also adding the modern backend (the default is `.__legacy__`, which just adds an extra path before running setup.py).
