### PR TITLE
Declare docutils as a direct dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     install_requires=[
+        'docutils',
         'Sphinx>=5.0.0',
     ],
     extras_require={

--- a/src/sphinxcontrib/programoutput/tests/test_setup.py
+++ b/src/sphinxcontrib/programoutput/tests/test_setup.py
@@ -25,6 +25,7 @@
 
 from __future__ import print_function, division, absolute_import
 
+from importlib import metadata
 import unittest
 from . import AppMixin
 
@@ -38,6 +39,12 @@ class TestSetup(AppMixin,
         app = self.app
         self.assertIsInstance(app.env.programoutput_cache, ProgramOutputCache)
         self.assertFalse(app.env.programoutput_cache)
+
+
+    def test_docutils_is_a_direct_dependency(self):
+        requirements = metadata.requires('sphinxcontrib-programoutput')
+
+        self.assertIn('docutils', requirements or ())
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
## Summary

- add `docutils` to `install_requires` because `sphinxcontrib.programoutput` imports it directly at module import time
- add a regression assertion that installed package metadata includes the direct `docutils` requirement

## Verification

- `python3 -m py_compile setup.py src/sphinxcontrib/programoutput/tests/test_setup.py`
- `UV_NO_CACHE=1 uv run --with zope.testrunner --with coverage --with '.[test]' coverage run -p -m zope.testrunner --test-path=src` (`63 tests`, `0 failures`, `0 errors`, `1 skipped`)
- `UV_NO_CACHE=1 uv build`
- `unzip -p dist/sphinxcontrib_programoutput-0.20.dev0-py3-none-any.whl '*/METADATA' | rg -n '^Requires-Dist: (docutils|Sphinx)'`
- `git diff --check`

I used an AI coding assistant to prepare this patch.

Fixes #79
